### PR TITLE
Force python2.7 usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,9 @@ Link: https://bugs.launchpad.net/oslo.config/+bug/1869929
 
 Clone the repo and run `tox`.
 
-$python --version
-Python 2.7.12
-
-$git clone https://github.com/tobias-urdin/reproduce-bug-1869929
-
-$tox
+```
+$ git clone https://github.com/tobias-urdin/reproduce-bug-1869929
+$ tox
 ..snip output..
 RuntimeError: maximum recursion depth exceeded
+```

--- a/tox.ini
+++ b/tox.ini
@@ -8,4 +8,5 @@ install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
 
 [testenv:reproduce]
+basepython = python2.7
 commands = python {toxinidir}/reproduce.py


### PR DESCRIPTION
Simply force `tox` to use python 2.7 as the default interpreter to run the POC